### PR TITLE
Revert "export specialchars support" not supported by linux

### DIFF
--- a/application/controllers/admin/Sessions.php
+++ b/application/controllers/admin/Sessions.php
@@ -276,7 +276,6 @@ class Sessions extends CI_Controller {
         foreach ($questionData->result_array() as $value)
         {   
             // print_r($value);
-            $value = mb_convert_encoding($value, 'UTF-16BE', "auto");
              fputcsv($file,$value);    
         }
     }else{


### PR DESCRIPTION
This reverts commit 700c4363537c040d7c31508174a9e5b81d5f04a6.